### PR TITLE
Vertical scroll items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@tailwindcss/vite": "^4.1.18",
@@ -1979,6 +1980,19 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/sortable": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@tailwindcss/vite": "^4.1.18",

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -6,6 +6,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import {
   SortableContext,
   verticalListSortingStrategy,
@@ -35,6 +36,7 @@ function TodoList({ todos, onToggle, onDelete, onReorder }) {
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
+      modifiers={[restrictToVerticalAxis]}
       onDragEnd={handleDragEnd}
     >
       <SortableContext items={todos.map(t => t.id)} strategy={verticalListSortingStrategy}>

--- a/src/components/__tests__/TodoList.test.jsx
+++ b/src/components/__tests__/TodoList.test.jsx
@@ -1,11 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import TodoList from '../TodoList';
 
+// Mock @dnd-kit/modifiers
+jest.mock('@dnd-kit/modifiers', () => ({
+  restrictToVerticalAxis: jest.fn(),
+}));
+
 // Mock @dnd-kit/core
 const mockOnDragEnd = jest.fn();
+const mockDndContextModifiers = jest.fn();
 jest.mock('@dnd-kit/core', () => ({
-  DndContext: ({ children, onDragEnd }) => {
+  DndContext: ({ children, onDragEnd, modifiers }) => {
     mockOnDragEnd.mockImplementation(onDragEnd);
+    mockDndContextModifiers.mockImplementation(() => modifiers);
     return <div data-testid="dnd-context">{children}</div>;
   },
   closestCenter: jest.fn(),
@@ -96,6 +103,14 @@ describe('TodoList', () => {
     render(<TodoList {...defaultProps} />);
     
     expect(screen.getByTestId('dnd-context')).toBeInTheDocument();
+  });
+
+  it('restricts dragging to the vertical axis to prevent horizontal page overflow', () => {
+    render(<TodoList {...defaultProps} />);
+
+    const { restrictToVerticalAxis } = jest.requireMock('@dnd-kit/modifiers');
+    const modifiers = mockDndContextModifiers();
+    expect(modifiers).toContain(restrictToVerticalAxis);
   });
 
   it('wraps content in SortableContext', () => {

--- a/src/components/__tests__/TodoListDragConstraint.test.jsx
+++ b/src/components/__tests__/TodoListDragConstraint.test.jsx
@@ -1,0 +1,54 @@
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+
+// Directly exercise the modifier that is wired into DndContext (see TodoList.test.jsx for wiring).
+// restrictToVerticalAxis is what prevents the page from expanding horizontally during a drag.
+
+// Arguments shape that dnd-kit passes to every modifier at runtime
+const modifierArgs = {
+  transform: null,
+  active: null,
+  over: null,
+  activeNodeRect: null,
+  draggingNodeRect: null,
+  overlappingRect: null,
+  rects: null,
+  windowRect: null,
+  scrollableAncestors: [],
+  scrollableAncestorRects: [],
+  activatorEvent: null,
+};
+
+describe('restrictToVerticalAxis modifier — prevents horizontal page overflow during drag', () => {
+  it('zeroes out x-translation when dragged far to the right edge of the screen', () => {
+    // Simulate pointer having moved 2000px to the right and 50px down
+    const result = restrictToVerticalAxis({
+      ...modifierArgs,
+      transform: { x: 2000, y: 50, scaleX: 1, scaleY: 1 },
+    });
+
+    expect(result.x).toBe(0);   // must not expand the page horizontally
+    expect(result.y).toBe(50);  // vertical movement is preserved
+  });
+
+  it('zeroes out x-translation when dragged far to the left edge of the screen', () => {
+    const result = restrictToVerticalAxis({
+      ...modifierArgs,
+      transform: { x: -2000, y: -30, scaleX: 1, scaleY: 1 },
+    });
+
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(-30);
+  });
+
+  it('preserves zero x-translation when dragging only vertically', () => {
+    const result = restrictToVerticalAxis({
+      ...modifierArgs,
+      transform: { x: 0, y: 120, scaleX: 1, scaleY: 1 },
+    });
+
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(120);
+  });
+});
+
+


### PR DESCRIPTION
Closes #16

This PR fixes an issue with dragging todo items by restricting our axes of motion to vertical only. Items cannot be moved horizontally